### PR TITLE
Add Invoke-JiraGetDeployments

### DIFF
--- a/PowerJira/public/api-v2/issue/Invoke-JiraGetDeployments.ps1
+++ b/PowerJira/public/api-v2/issue/Invoke-JiraGetDeployments.ps1
@@ -13,7 +13,9 @@ function Invoke-JiraGetDeployments {
         $functionPath = "/jsw/graphql"
         $verb = "POST"
 
-        $query = New-Object RestMethodQueryParams
+        $query = New-Object RestMethodQueryParams @{
+            operation = "DevDetailsDialog"
+        }
 
         $gqlQuery = @'
 query DevDetailsDialog ($issueId: ID!) {

--- a/PowerJira/public/api-v2/issue/Invoke-JiraGetDeployments.ps1
+++ b/PowerJira/public/api-v2/issue/Invoke-JiraGetDeployments.ps1
@@ -1,0 +1,57 @@
+#https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-get
+function Invoke-JiraGetDeployments {
+    param (
+        # The ID of the issue
+        [Parameter(Mandatory,ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [int32]
+        $Id
+    )
+    begin {
+        $results = @()
+    }
+    process {
+        $functionPath = "/jsw/graphql?operation=DevDetailsDialog"
+        $verb = "POST"
+
+        $query = New-Object RestMethodQueryParams
+
+        $gqlQuery = @'
+query DevDetailsDialog ($issueId: ID!) {
+	developmentInformation(issueId: $issueId){
+		details {
+			deploymentProviders {
+				deployments {
+					displayName
+					url
+					state
+					lastUpdated
+					pipelineId
+					pipelineDisplayName
+					pipelineUrl
+					environment {
+						id
+						type
+						displayName
+					}
+				}
+			}
+		}
+	}
+}
+'@
+
+        $body = New-Object RestMethodJsonBody @{
+            operationName = "DevDetailsDialog"
+            query         = $gqlQuery
+            variables     = @{
+                issueId = $Id
+            }
+        }
+
+        $method = New-Object BodyRestMethod @($functionPath, $verb, $query, $body) 
+        $results += $method.Invoke($JiraContext)
+    }
+    end {
+        $results.data.developmentInformation.details.deploymentProviders.deployments
+    }
+}

--- a/PowerJira/public/api-v2/issue/Invoke-JiraGetDeployments.ps1
+++ b/PowerJira/public/api-v2/issue/Invoke-JiraGetDeployments.ps1
@@ -10,7 +10,7 @@ function Invoke-JiraGetDeployments {
         $results = @()
     }
     process {
-        $functionPath = "/jsw/graphql?operation=DevDetailsDialog"
+        $functionPath = "/jsw/graphql"
         $verb = "POST"
 
         $query = New-Object RestMethodQueryParams

--- a/demos/Demo-Deployments.ps1
+++ b/demos/Demo-Deployments.ps1
@@ -1,0 +1,18 @@
+#import PowerJira
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath \..\PowerJira\PowerJira.psm1) -Force
+
+#import the variable $JiraCredentials
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath \credentials\Credentials.psm1) -Force
+
+#open a new Jira session
+Open-JiraSession -UserName $JiraCredentials.UserName -Password $JiraCredentials.ApiToken -HostName $JiraCredentials.HostName
+
+#do tests here
+
+#GET DEPLOYMENTS ASSOCIATED WITH AN ISSUE
+# Invoke-JiraGetIssue -Key 10000 | Invoke-JiraGetDeployments
+
+#end tests
+
+#close the Jira session
+Close-JiraSession


### PR DESCRIPTION
Gets deployment info associated with an issue by an integration. Note that the `functionPath` won't match other commands in this repo. I'm not aware of any documentation for this path but it works with the same auth as `/rest/api/2/` calls:
`$functionPath = "/jsw/graphql?operation=DevDetailsDialog"`